### PR TITLE
Feat/view all matches

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -9,3 +9,5 @@
 import './styles/app.scss';
 
 import { Tooltip, Toast, Popover } from 'bootstrap';
+
+require('bootstrap-icons/font/bootstrap-icons.css');

--- a/composer.json
+++ b/composer.json
@@ -96,6 +96,7 @@
     "require-dev": {
         "doctrine/doctrine-fixtures-bundle": "^3.4",
         "fakerphp/faker": "^1.23",
+        "phpstan/phpstan": "^1.10",
         "phpunit/phpunit": "^9.5",
         "symfony/browser-kit": "6.3.*",
         "symfony/css-selector": "6.3.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c19dcb0e3b6e16308455e2bf0b93a6c9",
+    "content-hash": "02b91ba1ffc8776894cfd46d57b45bf6",
     "packages": [
         {
             "name": "api-platform/core",
@@ -8502,6 +8502,68 @@
                 "source": "https://github.com/phar-io/version/tree/3.2.1"
             },
             "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "1.10.33",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan.git",
+                "reference": "03b1cf9f814ba0863c4e9affea49a4d1ed9a2ed1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/03b1cf9f814ba0863c4e9affea49a4d1ed9a2ed1",
+                "reference": "03b1cf9f814ba0863c4e9affea49a4d1ed9a2ed1",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpstan/phpstan",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-09-04T12:20:53+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,8 @@
         "": {
             "license": "UNLICENSED",
             "dependencies": {
-                "bootstrap": "^5.3.1"
+                "bootstrap": "^5.3.1",
+                "bootstrap-icons": "^1.10.5"
             },
             "devDependencies": {
                 "@babel/core": "^7.17.0",
@@ -3150,6 +3151,21 @@
                 "@popperjs/core": "^2.11.8"
             }
         },
+        "node_modules/bootstrap-icons": {
+            "version": "1.10.5",
+            "resolved": "https://registry.npmjs.org/bootstrap-icons/-/bootstrap-icons-1.10.5.tgz",
+            "integrity": "sha512-oSX26F37V7QV7NCE53PPEL45d7EGXmBgHG3pDpZvcRaKVzWMqIRL9wcqJUyEha1esFtM3NJzvmxFXDxjJYD0jQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/twbs"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/bootstrap"
+                }
+            ]
+        },
         "node_modules/brace-expansion": {
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -4695,6 +4711,48 @@
             },
             "engines": {
                 "node": ">=0.8.0"
+            }
+        },
+        "node_modules/file-loader": {
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-6.2.0.tgz",
+            "integrity": "sha512-qo3glqyTa61Ytg4u73GultjHGjdRyig3tG6lPtyX/jOEJvHif9uB0/OCI2Kif6ctF3caQTW2G5gym21oAsI4pw==",
+            "dev": true,
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "loader-utils": "^2.0.0",
+                "schema-utils": "^3.0.0"
+            },
+            "engines": {
+                "node": ">= 10.13.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            },
+            "peerDependencies": {
+                "webpack": "^4.0.0 || ^5.0.0"
+            }
+        },
+        "node_modules/file-loader/node_modules/schema-utils": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
+            "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
+            "dev": true,
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@types/json-schema": "^7.0.8",
+                "ajv": "^6.12.5",
+                "ajv-keywords": "^3.5.2"
+            },
+            "engines": {
+                "node": ">= 10.13.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
             }
         },
         "node_modules/fill-range": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
         "build": "encore production --progress"
     },
     "dependencies": {
-        "bootstrap": "^5.3.1"
+        "bootstrap": "^5.3.1",
+        "bootstrap-icons": "^1.10.5"
     }
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,9 @@
+parameters:
+    level: 6
+    paths:
+        - bin/
+        - config/
+        - public/
+        - src/
+        - tests/
+    checkGenericClassInNonGenericObjectType: false

--- a/src/Controller/RencontreController.php
+++ b/src/Controller/RencontreController.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Controller;
+
+use App\Repository\RencontreRepository;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+class RencontreController extends AbstractController
+{
+    #[Route('/rencontre', name: 'app_rencontre')]
+    public function index(RencontreRepository $rencontreRepository): Response
+    {
+        $rencontres = $rencontreRepository->toutesLesRencontres();
+        return $this->render('rencontre/index.html.twig', [
+            'rencontres' => $rencontres,
+        ]);
+    }
+
+    #[Route('/rencontre/{id}', name: 'app_show_rencontre')]
+    public function show(RencontreRepository $rencontreRepository): Response
+    {
+        $rencontres = $rencontreRepository->toutesLesRencontres();
+        return $this->render('rencontre/show.html.twig', [
+            'rencontres' => $rencontres,
+        ]);
+    }
+}

--- a/src/Entity/Rencontre.php
+++ b/src/Entity/Rencontre.php
@@ -106,11 +106,29 @@ class Rencontre
         return $this->Statut;
     }
 
+    public function getStatutString(): ?string
+    {
+        $statuses = [
+            self::STATUT_A_VENIR => 'À venir',
+            self::STATUT_EN_COURS => 'En cours',
+            self::STATUT_TERMINE => 'Terminé'
+        ];
+        return $statuses[$this->Statut];
+    }
+
     public function setStatut(int $Statut): static
     {
         $this->Statut = $Statut;
-
         return $this;
+    }
+
+    public function getDisplayableScores(): ?string
+    {
+        if ($this->Statut == self::STATUT_A_VENIR) {
+            return '—';
+        } else {
+            return $this->ScoreEquipeA . ' - ' . $this->ScoreEquipeB;
+        }
     }
 
     public function getScoreEquipeA(): ?int

--- a/src/Repository/RencontreRepository.php
+++ b/src/Repository/RencontreRepository.php
@@ -33,27 +33,22 @@ class RencontreRepository extends ServiceEntityRepository
                  'dateMin' => $dateTime->format('Y-m-d 00:00:00'),
                  'dateMax' => $dateTime->format('Y-m-d 23:59:59')
             ])
-           ->orderBy('rencontre.HeureDebut', 'DESC')
+           ->orderBy('rencontre.HeureDebut', 'ASC')
            ->getQuery()
-           ->getResult()
-       ;
+           ->getResult();
    }
 
 
-//    /**
-//     * @return Rencontre[] Returns an array of Rencontre objects
-//     */
-//    public function findByExampleField($value): array
-//    {
-//        return $this->createQueryBuilder('r')
-//            ->andWhere('r.exampleField = :val')
-//            ->setParameter('val', $value)
-//            ->orderBy('r.id', 'ASC')
-//            ->setMaxResults(10)
-//            ->getQuery()
-//            ->getResult()
-//        ;
-//    }
+   /**
+    * @return Rencontre[] Retourne tous les matchs
+    */
+   public function toutesLesRencontres(): array
+   {
+        return $this->createQueryBuilder('rencontre')
+            ->orderBy('rencontre.HeureDebut', 'ASC')
+            ->getQuery()
+            ->getResult();
+   }
 
 //    public function findOneBySomeField($value): ?Rencontre
 //    {
@@ -61,7 +56,6 @@ class RencontreRepository extends ServiceEntityRepository
 //            ->andWhere('r.exampleField = :val')
 //            ->setParameter('val', $value)
 //            ->getQuery()
-//            ->getOneOrNullResult()
-//        ;
+//            ->getOneOrNullResult();
 //    }
 }

--- a/symfony.lock
+++ b/symfony.lock
@@ -75,6 +75,18 @@
             "config/packages/nelmio_cors.yaml"
         ]
     },
+    "phpstan/phpstan": {
+        "version": "1.10",
+        "recipe": {
+            "repo": "github.com/symfony/recipes-contrib",
+            "branch": "main",
+            "version": "1.0",
+            "ref": "d74d4d719d5f53856c9c13544aa22d44144b1819"
+        },
+        "files": [
+            "phpstan.neon"
+        ]
+    },
     "phpunit/phpunit": {
         "version": "9.6",
         "recipe": {

--- a/templates/home_page/index.html.twig
+++ b/templates/home_page/index.html.twig
@@ -76,7 +76,7 @@
         <div class="col-8 center-block">
             <h1 class="">Bienvenue sur l'application superbowl</h1>
             <a href="#" class="btn btn-primary">Se connecter</a>
-            <a href="#" class="btn btn-primary">Visualiser tous les matchs</a>
+            <a href="rencontre" class="btn btn-primary">Visualiser tous les matchs</a>
             <a href="#" class="btn btn-primary">Parier</a>
         </div>
         <div class="col-2"></div>
@@ -92,7 +92,7 @@
             <table class="table">
             {% for rencontre in rencontres %}
                 <tr>
-                    <td>{{ rencontre.heureDebut |date("H:m") }}</td>
+                    <td>{{ rencontre.heureDebut |date("H:i") }}</td>
                     <td>{{ rencontre.EquipeA.Nom |e}}</td>
                     <td><span class="badge rounded-pill bg-info text-dark">{{ rencontre.CoteEquipeA |e}} &mdash; {{ rencontre.CoteEquipeB |e}}</span></td>
                     <td>{{ rencontre.EquipeB.Nom |e}}</td>

--- a/templates/menu.html.twig
+++ b/templates/menu.html.twig
@@ -1,0 +1,22 @@
+
+<nav class="navbar navbar-expand-lg bg-light">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="#">SuperBowl</a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarSupportedContent">
+      <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+        <li class="nav-item">
+          <a class="nav-link active" aria-current="page" href="{{ path('app_home_page') }}">Accueil</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" href="{{ path('app_rencontre') }}">Matches</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" href="#">Se connecter</a>
+        </li>
+      </ul>
+    </div>
+  </div>
+</nav>

--- a/templates/rencontre/index.html.twig
+++ b/templates/rencontre/index.html.twig
@@ -1,0 +1,49 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Visualiser tous les matchs{% endblock %}
+
+{% block body %}
+
+{% include 'menu.html.twig' %}
+
+<div class="container-fluid">
+    <div class="row"><div class="col-12">&nbsp;</div></div>
+    <div class="row">
+        <div class="col-1"></div>
+        <div class="col-10">
+            <h2 id="titleMatches">Tous les matchs</h2>
+            {% if rencontres is empty %}
+            <p id="msgNoMatchFound">Oups ! Une erreur est apparue</p>
+            {% else %}
+            <table class="table">
+                <thead>
+                    <tr>
+                        <th>Date</th>
+                        <th>Heure début - fin</th>
+                        <th>Equipe A</th>
+                        <th>Cotes équipes A - B</th>
+                        <th>Equipe B</th>
+                        <th>Statut</th>
+                        <th>Score</th>
+                    </tr>
+                </thead>
+                <tbody>
+                {% for rencontre in rencontres %}
+                    <tr style="cursor:pointer;" onclick="window.location='{{ path('app_show_rencontre', {id: rencontre.id}) }}';">
+                        <td><i class="bi bi-caret-right-square-fill"></i>&nbsp;{{ rencontre.jour }}</td>
+                        <td>{{ rencontre.heureDebut |date("H:i") }} - {{ rencontre.heureFin |date("H:i") }}</td>
+                        <td>{{ rencontre.EquipeA.Nom |e }}</td>
+                        <td><span class="badge rounded-pill bg-info text-dark">{{ rencontre.CoteEquipeA |e}} &mdash; {{ rencontre.CoteEquipeB |e}}</span></td>
+                        <td>{{ rencontre.EquipeB.Nom |e }}</td>
+                        <td>{{ rencontre.statutString |e }}</td>
+                        <td>{{ rencontre.displayableScores |e }}</td>
+                    </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+            {% endif %}
+        </div>
+        <div class="col-1"></div>
+    </div>
+</div>
+{% endblock %}

--- a/templates/rencontre/show.html.twig
+++ b/templates/rencontre/show.html.twig
@@ -1,0 +1,14 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Visualiser tous les matchs{% endblock %}
+
+{% block body %}
+
+{% include 'menu.html.twig' %}
+
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-12">Work in progress</div>
+    </div>
+</div>
+{% endblock %}

--- a/tests/Controller/HomePageTest.php
+++ b/tests/Controller/HomePageTest.php
@@ -6,7 +6,7 @@ use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 class HomePageTest extends WebTestCase
 {
-    public function testSomething(): void
+    public function testHomepage(): void
     {
         $client = static::createClient();
         $crawler = $client->request('GET', '/');

--- a/tests/Controller/RencontreTest.php
+++ b/tests/Controller/RencontreTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Tests;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class RencontreTest extends WebTestCase
+{
+    public function testRencontreIndex(): void
+    {
+        $client = static::createClient();
+        $crawler = $client->request('GET', 'rencontre');
+
+        //Présence du menu
+        $this->assertSelectorExists('a[class=navbar-brand]');
+
+        //Contenu attendu
+        $this->assertResponseIsSuccessful();
+        $this->assertPageTitleContains("Visualiser tous les matchs");
+        $this->assertSelectorNotExists('p[id=msgNoMatchFound]');
+        $this->assertSelectorTextContains('h2[id=titleMatches]', 'Tous les matchs');
+    }
+}

--- a/tests/Entity/RencontreTest.php
+++ b/tests/Entity/RencontreTest.php
@@ -1,0 +1,42 @@
+<?php
+namespace App\Tests\Service;
+
+use App\Entity\Rencontre;
+
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class RencontreTest extends KernelTestCase
+{
+
+    public function testRencontreEnCours(): void
+    {
+        self::bootKernel();
+        $rencontre = new Rencontre();
+        $rencontre->setStatut(Rencontre::STATUT_EN_COURS);
+        $rencontre->setScoreEquipeA(75);
+        $rencontre->setScoreEquipeB(33);
+        $scores = $rencontre->getDisplayableScores();
+        $this->assertEquals("75 - 33", $scores);
+    }
+
+    public function testRencontreAVenir(): void
+    {
+        self::bootKernel();
+        $rencontre = new Rencontre();
+        $rencontre->setStatut(Rencontre::STATUT_A_VENIR);
+        $rencontre->setScoreEquipeA(1);
+        $rencontre->setScoreEquipeB(2);
+        $scores = $rencontre->getDisplayableScores();
+        $this->assertEquals('—', $scores);
+    }
+
+    private function testRencontreTerminee(): void {
+        self::bootKernel();
+        $rencontre = new Rencontre();
+        $rencontre->setStatut(Rencontre::STATUT_TERMINE);
+        $rencontre->setScoreEquipeA(55);
+        $rencontre->setScoreEquipeB(20);
+        $scores = $rencontre->getDisplayableScores();
+        $this->assertEquals("55 - 20", $scores);
+    }
+}


### PR DESCRIPTION
Cette PR fix #2 et contient les changements suivants:

- Création de la page listant tous les matches
- Ajout d'une première version de menu en tant que fragment twig (ne contenant pour l'instant pas de logique métier).
- Création d'un test d'IHM avec PHPUnit

On note que le lien vers le détail d'un match est fonctionnel, mais la page de détail est pour l'instant vide